### PR TITLE
Allow specifying extra {exec,target}_compatible_with conditions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,30 +180,39 @@ jobs:
         name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
         path: .
     - name: Generate toolchains.bzl
-      run: "cat >BUILD.bazel <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+      run: "cat >toolchains.bzl <<EOF\ndef register_musl_toolchains():\n    native.register_toolchains(\"\
+        @musl_toolchains_hub//:all\")\nEOF\n"
+    - name: Generate repositories.bzl
+      run: "cat >repositories.bzl <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\ndef _toolchain_repo(rctx):\n    rctx.file(\n      \
+        \  \"BUILD.bazel\",\n        \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
-        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
-        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
-        \    ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl//:musl_toolchain\"\
+        \     \"@platforms//os:linux\",\n    ] + rctx.attr.extra_exec_compatible_with,\n\
+        \    target_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ] + rctx.attr.extra_target_compatible_with,\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl//:musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
-        \     \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n  \
-        \      \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n  \
-        \  ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl//:musl_toolchain\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
-        EOF\n\ncat >toolchains.bzl <<EOF\ndef register_musl_toolchains():\n    native.register_toolchains(\"\
-        @musl_toolchains//:all\")\nEOF\n"
-    - name: Generate repositories.bzl
-      run: "cat >repositories.bzl <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\ndef load_musl_toolchains():\n    http_archive(\n  \
-        \      name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        \     \"@platforms//os:osx\",\n    ] + rctx.attr.extra_exec_compatible_with,\n\
+        \    target_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ] + rctx.attr.extra_target_compatible_with,\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl//:musl_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
+        \"\",\n    )\n\ntoolchain_repo = repository_rule(\n    implementation = _toolchain_repo,\n\
+        \    attrs = {\n        \"extra_exec_compatible_with\": attr.string_list(),\n\
+        \        \"extra_target_compatible_with\": attr.string_list(),\n    },\n)\n\
+        \ndef load_musl_toolchains(extra_exec_compatible_with=[], extra_target_compatible_with=[]):\n\
+        \    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
-        ,\n    )\n\nEOF\n"
+        ,\n    )\n\n\n    toolchain_repo(\n        name = \"musl_toolchains_hub\"\
+        ,\n        extra_exec_compatible_with = extra_exec_compatible_with,\n    \
+        \    extra_target_compatible_with = extra_target_compatible_with,\n    )\n\
+        EOF\n"
     - name: Generate release archive
       run: ./deterministic-tar.sh musl_toolchain-${{github.ref_name}}.tar.gz toolchains.bzl
         repositories.bzl BUILD.bazel


### PR DESCRIPTION
This allows people to differentiate their toolchains between musl and non-musl versions targeting the same OS+arch.

Fixes #6