### PR TITLE
Add support for Bzlmod

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,17 @@
+{
+  "homepage": "https://github.com/bazel-contrib/musl-toolchain",
+  "maintainers": [
+    {
+      "email": "dawagner@gmail.com",
+      "github": "illicitonion",
+      "name": "Daniel Wagner-Hall"
+    },
+    {
+      "email": "fabian@meumertzhe.im",
+      "github": "fmeum",
+      "name": "Fabian Meumertzheim"
+    }
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,10 @@
+bcr_test_module:
+  module_path: "bcr_test"
+  matrix:
+    platform: ["centos7", "debian10", "macos", "macos_arm64", "ubuntu2004"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      build_targets:
+        - "//..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,3 +8,11 @@ bcr_test_module:
       platform: ${{ platform }}
       build_targets:
         - "//..."
+      build_flags:
+        - "--test_output=errors"
+        - "--verbose_failures"
+      test_targets:
+        - "//..."
+      test_flags:
+        - "--test_output=errors"
+        - "--verbose_failures"

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/musl_toolchain-{TAG}.tar.gz"
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,48 +274,10 @@ jobs:
         if-no-files-found: error
   release:
     runs-on: ubuntu-latest
-    needs:
-    - unknown-linux-gnu-x86_64-x86_64
-    - apple-darwin-x86_64-x86_64
-    - apple-darwin-aarch64-x86_64
-    - unknown-linux-gnu-x86_64-aarch64
-    - apple-darwin-x86_64-aarch64
-    - apple-darwin-aarch64-aarch64
-    - test-x86_64
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
     - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
-    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
-        path: .
     - name: Generate MODULE.bazel
       run: "touch MODULE.bazel\n\ncat >MODULE.bazel <<'EOF'\nmodule(\n    name = \"\
         toolchains_musl\",\n    version = \"${{github.ref_name}}\",\n)\n\nbazel_dep(name\
@@ -465,58 +427,4 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl_toolchain-${{github.ref_name}}.tar.gz
         asset_path: musl_toolchain-${{github.ref_name}}.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         asset_content_type: application/gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,10 +274,48 @@ jobs:
         if-no-files-found: error
   release:
     runs-on: ubuntu-latest
+    needs:
+    - unknown-linux-gnu-x86_64-x86_64
+    - apple-darwin-x86_64-x86_64
+    - apple-darwin-aarch64-x86_64
+    - unknown-linux-gnu-x86_64-aarch64
+    - apple-darwin-x86_64-aarch64
+    - apple-darwin-aarch64-aarch64
+    - test-x86_64
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
     - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
     - name: Generate MODULE.bazel
       run: "touch MODULE.bazel\n\ncat >MODULE.bazel <<'EOF'\nmodule(\n    name = \"\
         toolchains_musl\",\n    version = \"${{github.ref_name}}\",\n)\n\nbazel_dep(name\
@@ -427,4 +465,58 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl_toolchain-${{github.ref_name}}.tar.gz
         asset_path: musl_toolchain-${{github.ref_name}}.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         asset_content_type: application/gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -316,6 +316,33 @@ jobs:
       with:
         name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         path: .
+    - name: Generate MODULE.bazel
+      run: "touch MODULE.bazel\n\ncat >MODULE.bazel <<'EOF'\nmodule(\n    name = \"\
+        toolchains_musl\",\n    version = \"${{github.ref_name}}\",\n)\n\nbazel_dep(name\
+        \ = \"bazel_features\", version = \"1.9.0\")\nbazel_dep(name = \"platforms\"\
+        , version = \"0.0.9\")\n\ntoolchains_musl = use_extension(\"//:toolchains_musl.bzl\"\
+        , \"toolchains_musl\")\nuse_repo(toolchains_musl, \"musl_toolchains_hub\"\
+        )\n\nregister_toolchains(\"@musl_toolchains_hub//:all\")\nEOF\n"
+    - name: Generate extensions.bzl
+      run: "touch musl_toolchains.bzl\n\ncat >musl_toolchains.bzl <<'EOF'\nload(\"\
+        @bazel_features//:features.bzl\", \"bazel_features\")\nload(\":repositories.bzl\"\
+        , \"load_musl_toolchains\")\n\ndef _toolchains_musl(module_ctx):\n    extra_exec_compatible_with\
+        \ = []\n    extra_target_compatible_with = []\n    for module in module_ctx.modules:\n\
+        \        if not module.is_root or not module.tags.config:\n            continue\n\
+        \        if len(module.tags.config) > 1:\n            fail(\n            \
+        \    \"Only one musl_toolchains.config tag is allowed, got\",\n          \
+        \      module.tags.config[0],\n                \"and\",\n                module.tags.config[1],\n\
+        \            )\n        config = module.tags.config[0]\n        extra_exec_compatible_with\
+        \ = config.extra_exec_compatible_with\n        extra_target_compatible_with\
+        \ = config.extra_target_compatible_with\n\n    load_musl_toolchains(\n   \
+        \     extra_exec_compatible_with = [str(label) for label in extra_exec_compatible_with],\n\
+        \        extra_target_compatible_with = [str(label) for label in extra_target_compatible_with],\n\
+        \    )\n\n    if bazel_features.external_deps.extension_metadata_has_reproducible:\n\
+        \        return module_ctx.extension_metadata(reproducible = True)\n    else:\n\
+        \        return None\n\n_config = tag_class(\n    attrs = {\n        \"extra_exec_compatible_with\"\
+        : attr.label_list(),\n        \"extra_target_compatible_with\": attr.label_list(),\n\
+        \    },\n)\n\ntoolchains_musl = module_extension(\n    implementation = _toolchains_musl,\n\
+        \    tag_classes = {\n        \"config\": _config,\n    },\n)\nEOF\n"
     - name: Generate toolchains.bzl
       run: "touch BUILD.bazel\n\ncat >toolchains.bzl <<EOF\ndef register_musl_toolchains():\n\
         \    native.register_toolchains(\"@musl_toolchains_hub//:all\")\nEOF\n"
@@ -390,14 +417,36 @@ jobs:
         ,\n        extra_exec_compatible_with = extra_exec_compatible_with,\n    \
         \    extra_target_compatible_with = extra_target_compatible_with,\n    )\n\
         EOF\n"
+    - name: Generate bcr_test/MODULE.bazel
+      run: "mkdir -p bcr_test\ntouch bcr_test/MODULE.bazel\n\ncat >bcr_test/MODULE.bazel\
+        \ <<'EOF'\nbazel_dep(name = \"toolchains_musl\")\nlocal_path_override(\n \
+        \   module_name = \"toolchains_musl\",\n    path = \"..\",\n)\n\nbazel_dep(name\
+        \ = \"aspect_bazel_lib\", version = \"2.7.7\")\nEOF\n"
+    - name: Generate bcr_test/BUILD.bazel
+      run: "mkdir -p bcr_test\ntouch bcr_test/BUILD.bazel\n\ncat >bcr_test/BUILD.bazel\
+        \ <<'EOF2'\nload(\"@aspect_bazel_lib//lib:transitions.bzl\", \"platform_transition_binary\"\
+        )\n\ngenrule(\n    name = \"generate_source\",\n    outs = [\"main.cc\"],\n\
+        \    cmd = \"\"\"cat >$@ <<EOF\n#include <stdio.h>\n\nint main(void) {\n \
+        \ printf(\"Built on $$(uname) $$(uname -m)\\\\n\");\n  return 0;\n}\nEOF\n\
+        \"\"\",\n)\n\ncc_binary(\n    name = \"binary\",\n    srcs = [\"main.cc\"\
+        ],\n    linkopts = [\"-static\"],\n    tags = [\"manual\"],\n)\n\nplatform_transition_binary(\n\
+        \    name = \"binary_linux_x86_64\",\n    binary = \":binary\",\n    target_platform\
+        \ = \":linux_x86_64\",\n)\n\nplatform_transition_binary(\n    name = \"binary_linux_aarch64\"\
+        ,\n    binary = \":binary\",\n    target_platform = \":linux_aarch64\",\n\
+        )\n\nplatform(\n    name = \"linux_x86_64\",\n    constraint_values = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ],\n)\n\nplatform(\n    name = \"linux_aarch64\",\n    constraint_values\
+        \ = [\n        \"@platforms//cpu:aarch64\",\n        \"@platforms//os:linux\"\
+        ,\n    ],\n)\nEOF2\n"
     - name: Generate release archive
-      run: ./deterministic-tar.sh musl_toolchain-${{github.ref_name}}.tar.gz toolchains.bzl
-        repositories.bzl BUILD.bazel
+      run: ./deterministic-tar.sh musl_toolchain-${{github.ref_name}}.tar.gz MODULE.bazel
+        musl_toolchains.bzl toolchains.bzl repositories.bzl BUILD.bazel bcr_test/MODULE.bazel
+        bcr_test/BUILD.bazel
     - name: Generate release body
       run: sha256=$(sha256sum musl_toolchain-${{github.ref_name}}.tar.gz | awk '{print
         $1}') ; url='https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl_toolchain-${{github.ref_name}}.tar.gz'
-        ; sed -e "s#{sha256}#${sha256}#g" -e "s#{url}#${url}#g" release.txt.template
-        > release-notes.txt
+        ; version='${{github.ref_name}}'; sed -e "s#{sha256}#${sha256}#g" -e "s#{url}#${url}#g"
+        -e "s|{version}|${version#v}|g" release.txt.template > release-notes.txt
     - id: create_release
       name: Create release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -324,15 +324,18 @@ jobs:
         , \"toolchains_musl\")\nuse_repo(toolchains_musl, \"musl_toolchains_hub\"\
         )\n\nregister_toolchains(\"@musl_toolchains_hub//:all\")\nEOF\n"
     - name: Generate extensions.bzl
-      run: "touch musl_toolchains.bzl\n\ncat >musl_toolchains.bzl <<'EOF'\nload(\"\
+      run: "touch toolchains_musl.bzl\n\ncat >toolchains_musl.bzl <<'EOF'\nload(\"\
         @bazel_features//:features.bzl\", \"bazel_features\")\nload(\":repositories.bzl\"\
         , \"load_musl_toolchains\")\n\ndef _toolchains_musl(module_ctx):\n    extra_exec_compatible_with\
         \ = []\n    extra_target_compatible_with = []\n    for module in module_ctx.modules:\n\
-        \        if not module.is_root or not module.tags.config:\n            continue\n\
-        \        if len(module.tags.config) > 1:\n            fail(\n            \
-        \    \"Only one musl_toolchains.config tag is allowed, got\",\n          \
-        \      module.tags.config[0],\n                \"and\",\n                module.tags.config[1],\n\
-        \            )\n        config = module.tags.config[0]\n        extra_exec_compatible_with\
+        \        if not module.tags.config:\n            continue\n        if not\
+        \ module.is_root:\n            fail(\"musl_toolchains.config can only be used\
+        \ from the root module. Add 'dev_dependency = True' to 'use_extension' to\
+        \ ignore it in non-root modules.\")\n        if len(module.tags.config) >\
+        \ 1:\n            fail(\n                \"Only one musl_toolchains.config\
+        \ tag is allowed, got\",\n                module.tags.config[0],\n       \
+        \         \"and\",\n                module.tags.config[1],\n            )\n\
+        \        config = module.tags.config[0]\n        extra_exec_compatible_with\
         \ = config.extra_exec_compatible_with\n        extra_target_compatible_with\
         \ = config.extra_target_compatible_with\n\n    load_musl_toolchains(\n   \
         \     extra_exec_compatible_with = [str(label) for label in extra_exec_compatible_with],\n\
@@ -421,27 +424,74 @@ jobs:
       run: "mkdir -p bcr_test\ntouch bcr_test/MODULE.bazel\n\ncat >bcr_test/MODULE.bazel\
         \ <<'EOF'\nbazel_dep(name = \"toolchains_musl\")\nlocal_path_override(\n \
         \   module_name = \"toolchains_musl\",\n    path = \"..\",\n)\n\nbazel_dep(name\
-        \ = \"aspect_bazel_lib\", version = \"2.7.7\")\nEOF\n"
+        \ = \"aspect_bazel_lib\", version = \"2.7.7\")\n\ntoolchains_musl = use_extension(\"\
+        @toolchains_musl//:toolchains_musl.bzl\", \"toolchains_musl\", dev_dependency\
+        \ = True)\ntoolchains_musl.config(\n    extra_target_compatible_with = [\"\
+        //:musl_on\"],\n)\nEOF\n"
     - name: Generate bcr_test/BUILD.bazel
       run: "mkdir -p bcr_test\ntouch bcr_test/BUILD.bazel\n\ncat >bcr_test/BUILD.bazel\
         \ <<'EOF2'\nload(\"@aspect_bazel_lib//lib:transitions.bzl\", \"platform_transition_binary\"\
-        )\n\ngenrule(\n    name = \"generate_source\",\n    outs = [\"main.cc\"],\n\
-        \    cmd = \"\"\"cat >$@ <<EOF\n#include <stdio.h>\n\nint main(void) {\n \
-        \ printf(\"Built on $$(uname) $$(uname -m)\\\\n\");\n  return 0;\n}\nEOF\n\
-        \"\"\",\n)\n\ncc_binary(\n    name = \"binary\",\n    srcs = [\"main.cc\"\
-        ],\n    linkopts = [\"-static\"],\n    tags = [\"manual\"],\n)\n\nplatform_transition_binary(\n\
+        )\n\npackage(default_visibility = [\"//visibility:public\"])\n\ngenrule(\n\
+        \    name = \"generate_source\",\n    outs = [\"main.cc\"],\n    cmd = \"\"\
+        \"cat >$@ <<EOF\n#include <stdio.h>\n\nint main(void) {\n  printf(\"Built\
+        \ on $$(uname) $$(uname -m)\\\\n\");\n  return 0;\n}\nEOF\n\"\"\",\n)\n\n\
+        cc_binary(\n    name = \"binary\",\n    srcs = [\"main.cc\"],\n    linkopts\
+        \ = [\"-static\"],\n    tags = [\"manual\"],\n)\n\nplatform_transition_binary(\n\
         \    name = \"binary_linux_x86_64\",\n    binary = \":binary\",\n    target_platform\
         \ = \":linux_x86_64\",\n)\n\nplatform_transition_binary(\n    name = \"binary_linux_aarch64\"\
         ,\n    binary = \":binary\",\n    target_platform = \":linux_aarch64\",\n\
-        )\n\nplatform(\n    name = \"linux_x86_64\",\n    constraint_values = [\n\
-        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
-        \    ],\n)\n\nplatform(\n    name = \"linux_aarch64\",\n    constraint_values\
-        \ = [\n        \"@platforms//cpu:aarch64\",\n        \"@platforms//os:linux\"\
-        ,\n    ],\n)\nEOF2\n"
+        )\n\nsh_test(\n    name = \"binary_test\",\n    srcs = [\"binary_test.sh\"\
+        ],\n    data = [\n        \":binary_linux_x86_64\",\n        \":binary_linux_aarch64\"\
+        ,\n    ],\n    env = {\n        \"BINARY_LINUX_X86_64\": \"$(rootpath :binary_linux_x86_64)\"\
+        ,\n        \"BINARY_LINUX_AARCH64\": \"$(rootpath :binary_linux_aarch64)\"\
+        ,\n    },\n)\n\nplatform(\n    name = \"linux_x86_64\",\n    constraint_values\
+        \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\"\
+        ,\n        \":musl_on\",\n    ],\n)\n\nplatform(\n    name = \"linux_aarch64\"\
+        ,\n    constraint_values = [\n        \"@platforms//cpu:aarch64\",\n     \
+        \   \"@platforms//os:linux\",\n        \":musl_on\",\n    ],\n)\n\nconstraint_setting(\n\
+        \    name = \"musl\",\n    default_constraint_value = \":musl_off\",\n)\n\
+        constraint_value(\n    name = \"musl_on\",\n    constraint_setting = \":musl\"\
+        ,\n)\nconstraint_value(\n    name = \"musl_off\",\n    constraint_setting\
+        \ = \":musl\",\n)\nEOF2\n"
+    - name: Generate bcr_test/binary_test.sh
+      run: 'mkdir -p bcr_test
+
+        touch bcr_test/binary_test.sh
+
+        chmod +x bcr_test/binary_test.sh
+
+
+        cat >bcr_test/binary_test.sh <<''EOF''
+
+        #!/usr/bin/env bash
+
+
+        set -euo pipefail
+
+
+        file "$BINARY_LINUX_X86_64" | grep ''statically linked'' || (echo "Binary
+        $BINARY_LINUX_X86_64 is not statically linked" && exit 1)
+
+        file "$BINARY_LINUX_X86_64" | grep ''x86-64'' || (echo "Binary $BINARY_LINUX_X86_64
+        is not x86-64" && exit 1)
+
+
+        file "$BINARY_LINUX_AARCH64" | grep ''statically linked'' || (echo "Binary
+        $BINARY_LINUX_AARCH64 is not statically linked" && exit 1)
+
+        file "$BINARY_LINUX_AARCH64" | grep ''aarch64'' || (echo "Binary $BINARY_LINUX_AARCH64
+        is not aarch64" && exit 1)
+
+
+        echo "All tests passed"
+
+        EOF
+
+        '
     - name: Generate release archive
       run: ./deterministic-tar.sh musl_toolchain-${{github.ref_name}}.tar.gz MODULE.bazel
-        musl_toolchains.bzl toolchains.bzl repositories.bzl BUILD.bazel bcr_test/MODULE.bazel
-        bcr_test/BUILD.bazel
+        toolchains_musl.bzl toolchains.bzl repositories.bzl BUILD.bazel bcr_test/MODULE.bazel
+        bcr_test/BUILD.bazel bcr_test/binary_test.sh
     - name: Generate release body
       run: sha256=$(sha256sum musl_toolchain-${{github.ref_name}}.tar.gz | awk '{print
         $1}') ; url='https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl_toolchain-${{github.ref_name}}.tar.gz'

--- a/build.sh
+++ b/build.sh
@@ -34,8 +34,8 @@ git clone https://github.com/bazel-contrib/musl-cross-make.git "${working_direct
 cd "${working_directory}"
 git checkout 687e64a549b2992bea42bd4e6cdbd0d1bd829ddb
 
-TARGET="${TARGET}" make MUSL_VER="${MUSL_VERSION}"
-TARGET="${TARGET}" make MUSL_VER="${MUSL_VERSION}" install
+TARGET="${TARGET}" make MUSL_VER="${MUSL_VERSION}" GNU_SITE="https://mirror.netcologne.de/gnu/"
+TARGET="${TARGET}" make MUSL_VER="${MUSL_VERSION}" GNU_SITE="https://mirror.netcologne.de/gnu/" install
 
 cd output
 

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -673,14 +673,14 @@ def make_jobs(release, version):
         release_archive_path = f"musl_toolchain-{version}.tar.gz"
         jobs["release"] = {
             "runs-on": "ubuntu-latest",
-            "needs": [job.build_job_name for job in releasable_artifacts] + test_jobs,
+            # "needs": [job.build_job_name for job in releasable_artifacts] + test_jobs,
             "steps": [
                          checkout,
                          {
                              "run": "sudo ln -s /usr/bin/tar /usr/bin/gnutar",
                          },
                      ]
-                     + [download(artifact.musl_filename) for artifact in releasable_artifacts]
+                    #  + [download(artifact.musl_filename) for artifact in releasable_artifacts]
                      + generate_release_archive(releasable_artifacts, release_archive_path, version)
                      + [
                          generate_release_body(release_body_path, release_archive_path, version),
@@ -702,10 +702,10 @@ def make_jobs(release, version):
                          },
                          upload_release_archive_artifact(release_archive_path),
                      ]
-                     + [
-                         upload_release_archive_artifact(artifact.musl_filename)
-                         for artifact in releasable_artifacts
-                     ],
+                    #  + [
+                    #      upload_release_archive_artifact(artifact.musl_filename)
+                    #      for artifact in releasable_artifacts
+                    #  ],
         }
     return jobs
 

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -673,14 +673,14 @@ def make_jobs(release, version):
         release_archive_path = f"musl_toolchain-{version}.tar.gz"
         jobs["release"] = {
             "runs-on": "ubuntu-latest",
-            # "needs": [job.build_job_name for job in releasable_artifacts] + test_jobs,
+            "needs": [job.build_job_name for job in releasable_artifacts] + test_jobs,
             "steps": [
                          checkout,
                          {
                              "run": "sudo ln -s /usr/bin/tar /usr/bin/gnutar",
                          },
                      ]
-                    #  + [download(artifact.musl_filename) for artifact in releasable_artifacts]
+                     + [download(artifact.musl_filename) for artifact in releasable_artifacts]
                      + generate_release_archive(releasable_artifacts, release_archive_path, version)
                      + [
                          generate_release_body(release_body_path, release_archive_path, version),
@@ -702,10 +702,10 @@ def make_jobs(release, version):
                          },
                          upload_release_archive_artifact(release_archive_path),
                      ]
-                    #  + [
-                    #      upload_release_archive_artifact(artifact.musl_filename)
-                    #      for artifact in releasable_artifacts
-                    #  ],
+                     + [
+                         upload_release_archive_artifact(artifact.musl_filename)
+                         for artifact in releasable_artifacts
+                     ],
         }
     return jobs
 

--- a/musl-toolchain.BUILD.bazel.template
+++ b/musl-toolchain.BUILD.bazel.template
@@ -1,5 +1,4 @@
 load("//:musl_cc_toolchain_config.bzl", "musl_cc_toolchain_config")
-load("@rules_cc//cc:defs.bzl", "cc_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/release.txt.template
+++ b/release.txt.template
@@ -4,6 +4,15 @@ To use this release, paste the following into your `MODULE.bazel` file:
 bazel_dep(name = "toolchains_musl", version = "{version}", dev_dependency = True)
 ```
 
+If you need to attach custom exec or target constraints to these toolchains, you can write:
+```starlark
+toolchains_musl = use_extension("@toolchains_musl//:toolchains_musl.bzl", "toolchains_musl", dev_dependency = True)
+toolchains_musl.config(
+    extra_exec_compatible_with = ["//some/constraint:label"],
+    extra_target_compatible_with = ["@some//other/constraint:label"],
+)
+```
+
 If you are using `WORKSPACE`, paste the following instead:
 
 ```starlark

--- a/release.txt.template
+++ b/release.txt.template
@@ -1,6 +1,12 @@
-To use this release, past the following into your WORKSPACE file:
+To use this release, paste the following into your `MODULE.bazel` file:
 
+```starlark
+bazel_dep(name = "toolchains_musl", version = "{version}", dev_dependency = True)
 ```
+
+If you are using `WORKSPACE`, paste the following instead:
+
+```starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(


### PR DESCRIPTION
* Adds a `MODULE.bazel` file with the name `toolchains_musl`, following the naming scheme of all other toolchain modules in the BCR.
* Adds a `toolchains_musl` module extension that can be used to set extra constraints.
* Adds a BCR test module to the release archive.