### PR TITLE
Rename cc_toolchain from musl_toolchain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
@@ -108,7 +108,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:osx\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
@@ -164,7 +164,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:arm64\",\n        \"@platforms//os:osx\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,17 +49,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
@@ -105,17 +106,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:osx\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n  \
+        \      \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n  \
+        \  ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
@@ -161,17 +163,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:arm64\",\n        \"@platforms//os:osx\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n   \
+        \     \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n   \
+        \ ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,8 +43,8 @@ jobs:
         && chmod 0755 /usr/local/bin/bazel
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
@@ -100,8 +100,8 @@ jobs:
       run: bazel --version
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
@@ -157,8 +157,8 @@ jobs:
       run: bazel --version
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,8 +45,8 @@ jobs:
         && chmod 0755 /usr/local/bin/bazel
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
@@ -102,8 +102,8 @@ jobs:
       run: bazel --version
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
@@ -159,8 +159,8 @@ jobs:
       run: bazel --version
     - name: Generate builder workspace file
       run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl_toolchain\",\n   \
-        \ sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,17 +51,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
@@ -107,17 +108,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:osx\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n  \
+        \      \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n  \
+        \  ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
@@ -163,17 +165,18 @@ jobs:
         ,\n)\n\nEOF\n"
     - name: Generate builder workspace config BUILD.bazel file
       run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
-        \ = [\n        \"@platforms//cpu:arm64\",\n        \"@platforms//os:osx\"\
-        ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n   \
+        \     \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n   \
+        \ ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
         EOF\n"
     - name: Build test binary and test with musl
       run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl_toolchain
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl
         --incompatible_enable_cc_toolchain_resolution
     - name: Move test binary
       run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
@@ -110,7 +110,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:osx\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
@@ -166,7 +166,7 @@ jobs:
         \ <<EOF\ntoolchain(\n    name = \"musl_toolchain\",\n    exec_compatible_with\
         \ = [\n        \"@platforms//cpu:arm64\",\n        \"@platforms//os:osx\"\
         ,\n    ],\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain//:musl_toolchain\"\
+        ,\n        \"@platforms//os:linux\",\n    ],\n    toolchain = \"@musl_toolchain\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
         platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
         @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
@@ -362,42 +362,42 @@ jobs:
         \     \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
         \    \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
         \    \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl//:musl_toolchain\"\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\",\n    )\n\ntoolchain_repo = repository_rule(\n    implementation = _toolchain_repo,\n\
         \    attrs = {\n        \"extra_exec_compatible_with\": attr.string_list(),\n\

--- a/build.sh
+++ b/build.sh
@@ -44,14 +44,16 @@ if [[ "Linux" == "$(uname)" ]]; then
   find bin libexec -type f -executable -exec strip {} \;
 fi
 
+output_name_without_extension="musl-${MUSL_VERSION}-platform-${PLATFORM}-target-${TARGET}"
+
 cp "${this_dir}/musl_cc_toolchain_config.bzl" ./
-sed -e "s#{{target_arch}}#${TARGET_ARCH}#g" "${this_dir}/musl-toolchain.BUILD.bazel.template" > ./BUILD.bazel
+sed -e "s#{{target_arch}}#${TARGET_ARCH}#g" -e "s#{{toolchain_name}}#${output_name_without_extension//./_}#g" "${this_dir}/musl-toolchain.BUILD.bazel.template" > ./BUILD.bazel
 
 included_files=(musl_cc_toolchain_config.bzl BUILD.bazel bin include lib libexec "${TARGET}")
 
 output_dir="${this_dir}/output"
 mkdir -p "${output_dir}"
-file_name="musl-${MUSL_VERSION}-platform-${PLATFORM}-target-${TARGET}.tar.gz"
+file_name="${output_name_without_extension}.tar.gz"
 output_file="${output_dir}/${file_name}"
 "${this_dir}/deterministic-tar.sh" "${output_file}" "${included_files[@]}"
 

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -277,7 +277,7 @@ def generate_toolchain(
         to_return += ' + """ + repr(' + extra_target_compatible_expr + ') + """'
 
     to_return += f""",
-    toolchain = "@{repo_name}//:musl_toolchain",
+    toolchain = "@{repo_name}",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 """

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -200,11 +200,13 @@ EOF
     }
 
 
-def generate_builder_workspace_file(source_os, musl_filename):
+def generate_builder_workspace_file(source_os: OS, source_arch: Architecture, target_arch: Architecture) -> str:
+    musl_filename = musl_filename_without_extension(source_os, source_arch, target_arch) + ".tar.gz"
+    repository_name = musl_toolchain_target_name(source_os, source_arch, target_arch)
     content = f"""load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "musl_toolchain",
+    name = "{repository_name}",
     sha256 = "$({get_platform_sha256sum(source_os)} {musl_filename} | awk '{{print $1}}')",
     url = "file://$(pwd)/{musl_filename}",
 )
@@ -689,7 +691,7 @@ def make_jobs(release, version):
                     checkout,
                     download(musl_filename),
                     install_bazel(source_os, source_arch),
-                    generate_builder_workspace_file(source_os, musl_filename),
+                    generate_builder_workspace_file(source_os, source_arch, target_arch),
                     generate_builder_workspace_config_build_file(
                         source_os, source_arch, target_arch
                     ),

--- a/musl-toolchain.BUILD.bazel.template
+++ b/musl-toolchain.BUILD.bazel.template
@@ -32,7 +32,7 @@ filegroup(
 musl_cc_toolchain_config(name = "k8_musl_toolchain_config", target_arch = "{{target_arch}}")
 
 cc_toolchain(
-    name = "musl_toolchain",
+    name = "{{toolchain_name}}",
     all_files = ":all_files",
     ar_files = ":musl_ar_files",
     as_files = ":all_files",


### PR DESCRIPTION
Before https://github.com/bazelbuild/bazel/pull/22738 the toolchain name was the only disambiguator in output directories, so using multiple musl toolchains in one build caused a conflicting actions error.