### PR TITLE
Use correct target arch in directory name for glob

### DIFF
--- a/musl-toolchain.BUILD.bazel.template
+++ b/musl-toolchain.BUILD.bazel.template
@@ -26,7 +26,7 @@ filegroup(name = "empty")
 
 filegroup(
     name = "dynamic_runtime_lib",
-    srcs = glob(["x86_64-linux-musl/lib/*.so*"]),
+    srcs = glob(["{{target_arch}}-linux-musl/lib/*.so*"]),
 )
 
 musl_cc_toolchain_config(name = "k8_musl_toolchain_config", target_arch = "{{target_arch}}")

--- a/test-workspaces/builder/.bazelrc
+++ b/test-workspaces/builder/.bazelrc
@@ -1,0 +1,1 @@
+common --incompatible_disallow_empty_glob


### PR DESCRIPTION
Also, disallow empty globs so we'd catch this in the future.