### PR TITLE
Add Linux aarch64 builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,64 +70,6 @@ jobs:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         if-no-files-found: error
-  unknown-linux-gnu-aarch64-x86_64:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
-    - name: Build musl
-      run: ./build.sh x86_64
-    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/upload-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-x86_64-test-build:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    needs:
-    - unknown-linux-gnu-aarch64-x86_64
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: .
-    - name: Download bazelisk as bazel
-      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
-        && chmod 0755 /usr/local/bin/bazel
-    - name: Generate builder workspace file
-      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
-        ,\n)\n\nEOF\n"
-    - name: Generate builder workspace config BUILD.bazel file
-      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
-        \       \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n \
-        \   ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
-        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
-        @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
-        EOF\n"
-    - name: Build test binary and test with musl
-      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        --incompatible_enable_cc_toolchain_resolution
-    - name: Move test binary
-      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        if-no-files-found: error
   apple-darwin-x86_64-x86_64:
     runs-on: macos-12
     steps:
@@ -247,7 +189,6 @@ jobs:
     container: centos:centos8
     needs:
     - unknown-linux-gnu-x86_64-x86_64-test-build
-    - unknown-linux-gnu-aarch64-x86_64-test-build
     - apple-darwin-x86_64-x86_64-test-build
     - apple-darwin-aarch64-x86_64-test-build
     steps:
@@ -257,11 +198,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
-        path: .
-    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
         path: .
     - name: Download test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
       uses: actions/download-artifact@v3
@@ -281,9 +217,6 @@ jobs:
         , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
         ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
-        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
         \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
@@ -292,6 +225,7 @@ jobs:
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n)\n\nEOF\n"
     - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
+        -- -//:built_binary_unknown-linux-gnu-aarch64
   unknown-linux-gnu-x86_64-aarch64:
     runs-on: ubuntu-latest
     container: centos:centos8
@@ -356,64 +290,6 @@ jobs:
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-aarch64:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
-    - name: Build musl
-      run: ./build.sh aarch64
-    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/upload-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-aarch64-test-build:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    needs:
-    - unknown-linux-gnu-aarch64-aarch64
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: .
-    - name: Download bazelisk as bazel
-      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
-        && chmod 0755 /usr/local/bin/bazel
-    - name: Generate builder workspace file
-      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
-        ,\n)\n\nEOF\n"
-    - name: Generate builder workspace config BUILD.bazel file
-      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
-        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
-        \  ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
-        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
-        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
-        EOF\n"
-    - name: Build test binary and test with musl
-      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-        --incompatible_enable_cc_toolchain_resolution
-    - name: Move test binary
-      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
         if-no-files-found: error
   apple-darwin-x86_64-aarch64:
     runs-on: macos-12
@@ -529,52 +405,3 @@ jobs:
         name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
         path: output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
         if-no-files-found: error
-  test-aarch64:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    needs:
-    - unknown-linux-gnu-x86_64-aarch64-test-build
-    - unknown-linux-gnu-aarch64-aarch64-test-build
-    - apple-darwin-x86_64-aarch64-test-build
-    - apple-darwin-aarch64-aarch64-test-build
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Download test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
-        path: .
-    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-        path: .
-    - name: Download test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
-        path: .
-    - name: Download test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
-        path: .
-    - name: Download bazelisk as bazel
-      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
-        && chmod 0755 /usr/local/bin/bazel
-    - name: Generate tester workspace file
-      run: "cat >test-workspaces/tester/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
-        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
-        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
-        \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-apple-darwin\",\n  \
-        \  executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
-        ,\n)\n\nEOF\n"
-    - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
     - name: Build musl
       run: ./build.sh x86_64
     - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
@@ -362,7 +362,7 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
     - name: Build musl
       run: ./build.sh aarch64
     - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,7 +225,7 @@ jobs:
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n)\n\nEOF\n"
     - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
-        -- -//:run_built_binary_unknown-linux-gnu-aarch64_test
+        -- -//:run_built_binary_aarch64-unknown-linux-gnu_test
   unknown-linux-gnu-x86_64-aarch64:
     runs-on: ubuntu-latest
     container: centos:centos8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,7 +225,7 @@ jobs:
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n)\n\nEOF\n"
     - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
-        -- -//:built_binary_unknown-linux-gnu-aarch64
+        -- -//:run_built_binary_unknown-linux-gnu-aarch64_test
   unknown-linux-gnu-x86_64-aarch64:
     runs-on: ubuntu-latest
     container: centos:centos8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,64 @@ jobs:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh x86_64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-x86_64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n \
+        \   ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        if-no-files-found: error
   apple-darwin-x86_64-x86_64:
     runs-on: macos-12
     steps:
@@ -189,6 +247,7 @@ jobs:
     container: centos:centos8
     needs:
     - unknown-linux-gnu-x86_64-x86_64-test-build
+    - unknown-linux-gnu-aarch64-x86_64-test-build
     - apple-darwin-x86_64-x86_64-test-build
     - apple-darwin-aarch64-x86_64-test-build
     steps:
@@ -198,6 +257,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
         path: .
     - name: Download test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
       uses: actions/download-artifact@v3
@@ -217,6 +281,9 @@ jobs:
         , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
         ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
         \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
@@ -245,6 +312,109 @@ jobs:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         if-no-files-found: error
+  unknown-linux-gnu-x86_64-aarch64-test-build:
+    runs-on: ubuntu-latest
+    container: centos:centos8
+    needs:
+    - unknown-linux-gnu-x86_64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n \
+        \   ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh aarch64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        if-no-files-found: error
   apple-darwin-x86_64-aarch64:
     runs-on: macos-12
     steps:
@@ -258,6 +428,49 @@ jobs:
       with:
         name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        if-no-files-found: error
+  apple-darwin-x86_64-aarch64-test-build:
+    runs-on: macos-12
+    needs:
+    - apple-darwin-x86_64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Skipping downloading bazelisk - already installed
+      run: bazel --version
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n  \
+        \      \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n   \
+        \ ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        path: output/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
         if-no-files-found: error
   apple-darwin-aarch64-aarch64:
     runs-on: macos-14
@@ -273,3 +486,95 @@ jobs:
         name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         if-no-files-found: error
+  apple-darwin-aarch64-aarch64-test-build:
+    runs-on: macos-14
+    needs:
+    - apple-darwin-aarch64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Skipping downloading bazelisk - already installed
+      run: bazel --version
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n   \
+        \     \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        path: output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        if-no-files-found: error
+  test-aarch64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-x86_64-aarch64-test-build
+    - unknown-linux-gnu-aarch64-aarch64-test-build
+    - apple-darwin-x86_64-aarch64-test-build
+    - apple-darwin-aarch64-aarch64-test-build
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate tester workspace file
+      run: "cat >test-workspaces/tester/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
+        \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-apple-darwin\",\n  \
+        \  executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n)\n\nEOF\n"
+    - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
     - name: Build musl
       run: ./build.sh x86_64
     - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
@@ -364,7 +364,7 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
     - name: Build musl
       run: ./build.sh aarch64
     - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,64 @@ jobs:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh x86_64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-x86_64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n \
+        \   ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        if-no-files-found: error
   apple-darwin-x86_64-x86_64:
     runs-on: macos-12
     steps:
@@ -191,6 +249,7 @@ jobs:
     container: centos:centos8
     needs:
     - unknown-linux-gnu-x86_64-x86_64-test-build
+    - unknown-linux-gnu-aarch64-x86_64-test-build
     - apple-darwin-x86_64-x86_64-test-build
     - apple-darwin-aarch64-x86_64-test-build
     steps:
@@ -200,6 +259,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
         path: .
     - name: Download test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
       uses: actions/download-artifact@v3
@@ -219,6 +283,9 @@ jobs:
         , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
         ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
         \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
@@ -247,6 +314,109 @@ jobs:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         if-no-files-found: error
+  unknown-linux-gnu-x86_64-aarch64-test-build:
+    runs-on: ubuntu-latest
+    container: centos:centos8
+    needs:
+    - unknown-linux-gnu-x86_64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n \
+        \   ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh aarch64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        if-no-files-found: error
   apple-darwin-x86_64-aarch64:
     runs-on: macos-12
     steps:
@@ -260,6 +430,49 @@ jobs:
       with:
         name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        if-no-files-found: error
+  apple-darwin-x86_64-aarch64-test-build:
+    runs-on: macos-12
+    needs:
+    - apple-darwin-x86_64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Skipping downloading bazelisk - already installed
+      run: bazel --version
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n  \
+        \      \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n   \
+        \ ],\n    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        path: output/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
         if-no-files-found: error
   apple-darwin-aarch64-aarch64:
     runs-on: macos-14
@@ -275,16 +488,111 @@ jobs:
         name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         path: output/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         if-no-files-found: error
+  apple-darwin-aarch64-aarch64-test-build:
+    runs-on: macos-14
+    needs:
+    - apple-darwin-aarch64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Skipping downloading bazelisk - already installed
+      run: bazel --version
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(shasum -a 256 musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:osx\",\n    ],\n    target_compatible_with = [\n   \
+        \     \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        path: output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        if-no-files-found: error
+  test-aarch64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-x86_64-aarch64-test-build
+    - unknown-linux-gnu-aarch64-aarch64-test-build
+    - apple-darwin-x86_64-aarch64-test-build
+    - apple-darwin-aarch64-aarch64-test-build
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
+        path: .
+    - name: Download test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate tester workspace file
+      run: "cat >test-workspaces/tester/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
+        \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-apple-darwin\",\n  \
+        \  executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n)\n\nEOF\n"
+    - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
   release:
     runs-on: ubuntu-latest
     needs:
     - unknown-linux-gnu-x86_64-x86_64
+    - unknown-linux-gnu-aarch64-x86_64
     - apple-darwin-x86_64-x86_64
     - apple-darwin-aarch64-x86_64
     - unknown-linux-gnu-x86_64-aarch64
+    - unknown-linux-gnu-aarch64-aarch64
     - apple-darwin-x86_64-aarch64
     - apple-darwin-aarch64-aarch64
     - test-x86_64
+    - test-aarch64
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -293,6 +601,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
         path: .
     - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
       uses: actions/download-artifact@v3
@@ -308,6 +621,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         path: .
     - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
       uses: actions/download-artifact@v3
@@ -367,6 +685,13 @@ jobs:
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
+        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
+        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
+        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
@@ -387,6 +712,13 @@ jobs:
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
+        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
+        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
+        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
@@ -409,6 +741,9 @@ jobs:
         \    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
+        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
@@ -418,6 +753,9 @@ jobs:
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
@@ -541,6 +879,15 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
         asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
         asset_content_type: application/gzip
@@ -561,6 +908,15 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         asset_content_type: application/gzip
     - name: Upload release archive
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,64 +72,6 @@ jobs:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
         if-no-files-found: error
-  unknown-linux-gnu-aarch64-x86_64:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
-    - name: Build musl
-      run: ./build.sh x86_64
-    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/upload-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-x86_64-test-build:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    needs:
-    - unknown-linux-gnu-aarch64-x86_64
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: .
-    - name: Download bazelisk as bazel
-      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
-        && chmod 0755 /usr/local/bin/bazel
-    - name: Generate builder workspace file
-      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
-        ,\n)\n\nEOF\n"
-    - name: Generate builder workspace config BUILD.bazel file
-      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
-        \       \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n \
-        \   ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
-        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
-        @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
-        EOF\n"
-    - name: Build test binary and test with musl
-      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        --incompatible_enable_cc_toolchain_resolution
-    - name: Move test binary
-      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-        if-no-files-found: error
   apple-darwin-x86_64-x86_64:
     runs-on: macos-12
     steps:
@@ -244,14 +186,72 @@ jobs:
         name: test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl
         path: output/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl
         if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh x86_64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-x86_64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-x86_64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n \
+        \   ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        if-no-files-found: error
   test-x86_64:
     runs-on: ubuntu-latest
     container: centos:centos8
     needs:
     - unknown-linux-gnu-x86_64-x86_64-test-build
-    - unknown-linux-gnu-aarch64-x86_64-test-build
     - apple-darwin-x86_64-x86_64-test-build
     - apple-darwin-aarch64-x86_64-test-build
+    - unknown-linux-gnu-aarch64-x86_64-test-build
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -259,11 +259,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl
-        path: .
-    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
         path: .
     - name: Download test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl
       uses: actions/download-artifact@v3
@@ -275,6 +270,11 @@ jobs:
       with:
         name: test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl
         path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl
+        path: .
     - name: Download bazelisk as bazel
       run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64
         && chmod 0755 /usr/local/bin/bazel
@@ -283,17 +283,18 @@ jobs:
         , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
         ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
-        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
         \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-apple-darwin\",\n  \
         \  executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n)\n\nEOF\n"
-    - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
+    - run: 'cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
+        -- '
   unknown-linux-gnu-x86_64-aarch64:
     runs-on: ubuntu-latest
     container: centos:centos8
@@ -358,64 +359,6 @@ jobs:
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
         path: output/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-aarch64:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
-    - name: Build musl
-      run: ./build.sh aarch64
-    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/upload-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        if-no-files-found: error
-  unknown-linux-gnu-aarch64-aarch64-test-build:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    needs:
-    - unknown-linux-gnu-aarch64-aarch64
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: .
-    - name: Download bazelisk as bazel
-      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
-        && chmod 0755 /usr/local/bin/bazel
-    - name: Generate builder workspace file
-      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
-        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
-        ,\n)\n\nEOF\n"
-    - name: Generate builder workspace config BUILD.bazel file
-      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
-        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
-        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
-        \  ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
-        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
-        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
-        EOF\n"
-    - name: Build test binary and test with musl
-      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
-        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-        --incompatible_enable_cc_toolchain_resolution
-    - name: Move test binary
-      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
         if-no-files-found: error
   apple-darwin-x86_64-aarch64:
     runs-on: macos-12
@@ -531,13 +474,71 @@ jobs:
         name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
         path: output/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
         if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - run: sudo ln -s /usr/bin/tar /usr/bin/gnutar
+    - name: Build musl
+      run: ./build.sh aarch64
+    - name: Upload musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: output/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        if-no-files-found: error
+  unknown-linux-gnu-aarch64-aarch64-test-build:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    needs:
+    - unknown-linux-gnu-aarch64-aarch64
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download bazelisk as bazel
+      run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
+        && chmod 0755 /usr/local/bin/bazel
+    - name: Generate builder workspace file
+      run: "cat >test-workspaces/builder/WORKSPACE.bazel <<EOF\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\"\
+        , \"http_archive\")\n\nhttp_archive(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
+        ,\n)\n\nEOF\n"
+    - name: Generate builder workspace config BUILD.bazel file
+      run: "mkdir -p test-workspaces/builder/config && cat >test-workspaces/builder/config/BUILD.bazel\
+        \ <<EOF\ntoolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ],\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\n\
+        platform(\n    name = \"platform\",\n    constraint_values = [\n        \"\
+        @platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n    ],\n)\n\n\
+        EOF\n"
+    - name: Build test binary and test with musl
+      run: cd test-workspaces/builder && BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 bazel
+        build //:binary //:test --platforms=//config:platform --extra_toolchains=//config:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        --incompatible_enable_cc_toolchain_resolution
+    - name: Move test binary
+      run: mkdir output && cp test-workspaces/builder/bazel-bin/binary output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+    - name: Upload test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: output/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        if-no-files-found: error
   test-aarch64:
     runs-on: buildjet-2vcpu-ubuntu-2204-arm
     needs:
     - unknown-linux-gnu-x86_64-aarch64-test-build
-    - unknown-linux-gnu-aarch64-aarch64-test-build
     - apple-darwin-x86_64-aarch64-test-build
     - apple-darwin-aarch64-aarch64-test-build
+    - unknown-linux-gnu-aarch64-aarch64-test-build
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
@@ -545,11 +546,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl
-        path: .
-    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
-      uses: actions/download-artifact@v3
-      with:
-        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
         path: .
     - name: Download test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl
       uses: actions/download-artifact@v3
@@ -561,6 +557,11 @@ jobs:
       with:
         name: test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl
         path: .
+    - name: Download test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+      uses: actions/download-artifact@v3
+      with:
+        name: test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl
+        path: .
     - name: Download bazelisk as bazel
       run: curl --fail -L -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-arm64
         && chmod 0755 /usr/local/bin/bazel
@@ -569,28 +570,29 @@ jobs:
         , \"http_file\")\n\nhttp_file(\n    name = \"built_binary_x86_64-unknown-linux-gnu\"\
         ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
-        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\
-        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_x86_64-apple-darwin\",\n   \
         \ executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-apple-darwin\",\n  \
         \  executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\
         \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
+        ,\n)\n\nhttp_file(\n    name = \"built_binary_aarch64-unknown-linux-gnu\"\
+        ,\n    executable = True,\n    sha256 = \"$(sha256sum test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\
+        \ | awk '{print $1}')\",\n    url = \"file://$(pwd)/test-binary-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n)\n\nEOF\n"
-    - run: cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
+    - run: 'cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all
+        -- '
   release:
     runs-on: ubuntu-latest
     needs:
     - unknown-linux-gnu-x86_64-x86_64
-    - unknown-linux-gnu-aarch64-x86_64
     - apple-darwin-x86_64-x86_64
     - apple-darwin-aarch64-x86_64
+    - unknown-linux-gnu-aarch64-x86_64
     - unknown-linux-gnu-x86_64-aarch64
-    - unknown-linux-gnu-aarch64-aarch64
     - apple-darwin-x86_64-aarch64
     - apple-darwin-aarch64-aarch64
+    - unknown-linux-gnu-aarch64-aarch64
     - test-x86_64
     - test-aarch64
     steps:
@@ -602,11 +604,6 @@ jobs:
       with:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
         path: .
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        path: .
     - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
       uses: actions/download-artifact@v3
       with:
@@ -617,15 +614,15 @@ jobs:
       with:
         name: musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz
         path: .
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        path: .
     - name: Download musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
       uses: actions/download-artifact@v3
       with:
         name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        path: .
-    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-      uses: actions/download-artifact@v3
-      with:
-        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         path: .
     - name: Download musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz
       uses: actions/download-artifact@v3
@@ -636,6 +633,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        path: .
+    - name: Download musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+      uses: actions/download-artifact@v3
+      with:
+        name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         path: .
     - name: Generate MODULE.bazel
       run: "touch MODULE.bazel\n\nversion=\"${{github.ref_name}}\"\n\ncat >MODULE.bazel\
@@ -685,13 +687,6 @@ jobs:
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
-        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
-        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
-        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:osx\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
@@ -706,19 +701,19 @@ jobs:
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
+        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
+        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:x86_64\"\
+        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
         \     \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
         \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
-        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
-        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
-        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
-        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
-        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
@@ -734,6 +729,13 @@ jobs:
         ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
+        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_exec_compatible_with)\
+        \ + \"\"\",\n    target_compatible_with = [\n        \"@platforms//cpu:arm64\"\
+        ,\n        \"@platforms//os:linux\",\n    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with)\
+        \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
         \"\",\n    )\n\ntoolchain_repo = repository_rule(\n    implementation = _toolchain_repo,\n\
         \    attrs = {\n        \"extra_exec_compatible_with\": attr.string_list(),\n\
         \        \"extra_target_compatible_with\": attr.string_list(),\n    },\n)\n\
@@ -741,27 +743,27 @@ jobs:
         \    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
-        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
-        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-apple-darwin-target-x86_64-linux-musl.tar.gz\"\
+        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl\"\
+        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
-        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
-        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
-        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-x86_64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
         ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\
         \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz\"\
+        ,\n    )\n\n    http_archive(\n        name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl\"\
+        ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\
+        \ | awk '{print $1}')\",\n        url = \"https://github.com/bazel-contrib/musl-toolchain/releases/download/${{github.ref_name}}/musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz\"\
         ,\n    )\n\n\n    toolchain_repo(\n        name = \"musl_toolchains_hub\"\
         ,\n        extra_exec_compatible_with = extra_exec_compatible_with,\n    \
         \    extra_target_compatible_with = extra_target_compatible_with,\n    )\n\
@@ -879,15 +881,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
-        asset_content_type: application/gzip
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
         asset_path: musl-1.2.3-platform-x86_64-apple-darwin-target-x86_64-linux-musl.tar.gz
         asset_content_type: application/gzip
@@ -906,8 +899,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz
         asset_content_type: application/gzip
     - name: Upload release archive
       uses: actions/upload-release-asset@v1
@@ -915,8 +908,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
-        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_name: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         asset_content_type: application/gzip
     - name: Upload release archive
       uses: actions/upload-release-asset@v1
@@ -935,4 +928,13 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_name: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
         asset_path: musl-1.2.3-platform-aarch64-apple-darwin-target-aarch64-linux-musl.tar.gz
+        asset_content_type: application/gzip
+    - name: Upload release archive
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_name: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
+        asset_path: musl-1.2.3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl.tar.gz
         asset_content_type: application/gzip

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 This toolchain allows cross-compiling binaries for Linux from various platforms. It can be used to produce binaries which don't dynamically link `libc`, by statically linking `musl`'s `libc` implementation.
 
+The supported target and execution platforms are:
+
+* Linux x86_64
+* Linux arm64
+* macOS x86_64
+* macOS arm64
+
+Due to limitations of Linux arm64 runners available for GitHub Actions, the toolchain requires glibc >= 2.35 to run on Linux arm64 executors.
+
 ## Setup
 
 Setup instructions are available with [each release](https://github.com/bazel-contrib/musl-toolchain/releases).

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,11 @@ TARGET="${TARGET_ARCH}-linux-musl"
 
 MUSL_VERSION=1.2.3
 if [[ "Linux" == "$(uname)" ]]; then
-    PLATFORM=x86_64-unknown-linux-gnu
+    if [[ "x86_64" == "$(uname -p)" ]]; then
+        PLATFORM=x86_64-unknown-linux-gnu
+    else
+        PLATFORM=aarch64-unknown-linux-gnu
+    fi
 
     working_directory="$(mktemp -d)"
     trap "rm -rf ${working_directory}" EXIT

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -121,8 +121,8 @@ linux_aarch64_runner = BaseRunner(
     top_level_properties={
         # This runner doesn't support nested virtualization or Ubuntu 20.04,
         # so we have to live with a glibc >= 2.35 requirement.
-        # The runner can be configured on the level of the bazel-contrib org
-        # by anyone with Admin or Owner access.
+        # Configuration requires admin access to this repo:
+        # https://app.buildjet.com/53858925
         "runs-on": "buildjet-2vcpu-ubuntu-2204-arm",
     },
     setup_steps=[

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -121,6 +121,8 @@ linux_aarch64_runner = BaseRunner(
     top_level_properties={
         # This runner doesn't support nested virtualization or Ubuntu 20.04,
         # so we have to live with a glibc >= 2.35 requirement.
+        # The runner can be configured on the level of the bazel-contrib org
+        # by anyone with Admin or Owner access.
         "runs-on": "buildjet-2vcpu-ubuntu-2204-arm",
     },
     setup_steps=[

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -121,7 +121,7 @@ linux_aarch64_runner = BaseRunner(
     top_level_properties={
         # This runner doesn't support nested virtualization or Ubuntu 20.04,
         # so we have to live with a glibc >= 2.35 requirement.
-        # Configuration requires admin access to this repo:
+        # It can be configured at (requires admin access to the repo):
         # https://app.buildjet.com/53858925
         "runs-on": "buildjet-2vcpu-ubuntu-2204-arm",
     },

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -117,6 +117,17 @@ linux_x86_64_runner = BaseRunner(
     ],
 )
 
+linux_aarch64_runner = BaseRunner(
+    top_level_properties={
+        "runs-on": "buildjet-2vcpu-ubuntu-2204-arm",
+    },
+    setup_steps=[
+        {
+            "run": "ln -s /usr/bin/tar /usr/bin/gnutar",
+        },
+    ],
+)
+
 _setup_darwin_steps = [
     {
         "run": "brew install wget md5sha1sum gnu-tar",
@@ -633,31 +644,32 @@ def make_jobs(release, version):
 
     source_machines = [
         (OS.Linux, Architecture.X86_64, linux_x86_64_runner),
+        (OS.Linux, Architecture.ARM64, linux_aarch64_runner),
         (OS.MacOS, Architecture.X86_64, darwin_x86_64_runner),
         (OS.MacOS, Architecture.ARM64, darwin_aarch64_runner),
     ]
 
     target_os = OS.Linux
-    target_arches = [
-        Architecture.X86_64,
-        Architecture.ARM64,
+    target_machines = [
+        (Architecture.X86_64, linux_x86_64_runner),
+        (Architecture.ARM64, linux_aarch64_runner),
     ]
 
     releasable_artifacts = []
     test_build_jobs = defaultdict(dict)
     test_jobs = []
 
-    for target_arch in target_arches:
-        for source_os, source_arch, runner in source_machines:
+    for target_arch, target_runner in target_machines:
+        for source_os, source_arch, source_runner in source_machines:
             build_job_name = (
                 f"{source_os.for_musl}-{source_arch.for_musl}-{target_arch.for_musl}"
             )
             musl_filename = musl_filename_without_extension(source_os, source_arch, target_arch) + ".tar.gz"
-            jobs[build_job_name] = runner.top_level_properties | {
+            jobs[build_job_name] = source_runner.top_level_properties | {
                 "steps": [
                              checkout,
                          ]
-                         + runner.setup_steps
+                         + source_runner.setup_steps
                          + [
                              {
                                  "name": "Build musl",
@@ -677,15 +689,9 @@ def make_jobs(release, version):
                 )
             )
 
-            # TODO: Make this unconditional when GitHub Actions supports Linux arm64 runners
-            # For now we just release these binaries without testing them
-            # (Currently in private beta: https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/)
-            # See https://github.com/actions/runner-images/issues/5631
-            if target_arch != Architecture.X86_64:
-                continue
             test_build_job_name = f"{source_os.for_musl}-{source_arch.for_musl}-{target_arch.for_musl}-test-build"
             test_build_filename = f"test-binary-platform-{source_arch.for_musl}-{source_os.for_musl}-target-{target_arch.for_musl}-linux-musl"
-            jobs[test_build_job_name] = runner.top_level_properties | {
+            jobs[test_build_job_name] = source_runner.top_level_properties | {
                 "needs": [build_job_name],
                 "steps": [
                     checkout,
@@ -713,15 +719,9 @@ def make_jobs(release, version):
                 "output": test_build_filename,
             }
 
-        # TODO: Make this unconditional when GitHub Actions supports Linux arm64 runners
-        # For now we just release these binaries without testing them
-        # (Currently in private beta: https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/)
-        # See https://github.com/actions/runner-images/issues/5631
-        if target_arch != Architecture.X86_64:
-            continue
         test_job_name = f"test-{target_arch.for_musl}"
         test_jobs.append(test_job_name)
-        jobs[test_job_name] = linux_x86_64_runner.top_level_properties | {
+        jobs[test_job_name] = target_runner.top_level_properties | {
             "needs": [
                 test_build_job["job_name"]
                 for _, test_build_job in test_build_jobs[target_arch].items()

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -744,7 +744,7 @@ def make_jobs(release, version):
                          install_bazel(target_os, target_arch),
                          generate_tester_workspace_file(test_build_jobs[target_arch]),
                          {
-                             "run": "cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all -- " + ("" if release else "-//:run_built_binary_unknown-linux-gnu-aarch64_test"),
+                             "run": "cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all -- " + ("" if release else "-//:run_built_binary_aarch64-unknown-linux-gnu_test"),
                          },
                      ],
         }

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -744,7 +744,7 @@ def make_jobs(release, version):
                          install_bazel(target_os, target_arch),
                          generate_tester_workspace_file(test_build_jobs[target_arch]),
                          {
-                             "run": "cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all -- " + ("" if release else "-//:built_binary_unknown-linux-gnu-aarch64"),
+                             "run": "cd test-workspaces/tester && CC=/bin/false bazel test ... --test_output=all -- " + ("" if release else "-//:run_built_binary_unknown-linux-gnu-aarch64_test"),
                          },
                      ],
         }

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -123,7 +123,7 @@ linux_aarch64_runner = BaseRunner(
     },
     setup_steps=[
         {
-            "run": "ln -s /usr/bin/tar /usr/bin/gnutar",
+            "run": "sudo ln -s /usr/bin/tar /usr/bin/gnutar",
         },
     ],
 )

--- a/test-workspaces/tester/BUILD.bazel
+++ b/test-workspaces/tester/BUILD.bazel
@@ -11,6 +11,7 @@
     )
     for source_os, source_arch, output_os, output_arch in [
         ("unknown-linux-gnu", "x86_64", "Linux", "x86_64"),
+        ("unknown-linux-gnu", "aarch64", "Linux", "arm64"),
         ("apple-darwin", "x86_64", "Darwin", "x86_64"),
         ("apple-darwin", "aarch64", "Darwin", "arm64"),
     ]


### PR DESCRIPTION
Restricted to release pipelines for now as the third-party runner isn't free to use for OSS and the billing setup is difficult for bazel-contrib.

Fixes #5 
Fixes #37 