### PR TITLE
Fix tester arch for Linux aarch64

### DIFF
--- a/test-workspaces/tester/BUILD.bazel
+++ b/test-workspaces/tester/BUILD.bazel
@@ -11,7 +11,7 @@
     )
     for source_os, source_arch, output_os, output_arch in [
         ("unknown-linux-gnu", "x86_64", "Linux", "x86_64"),
-        ("unknown-linux-gnu", "aarch64", "Linux", "arm64"),
+        ("unknown-linux-gnu", "aarch64", "Linux", "aarch64"),
         ("apple-darwin", "x86_64", "Darwin", "x86_64"),
         ("apple-darwin", "aarch64", "Darwin", "arm64"),
     ]


### PR DESCRIPTION
`uname -m` returns `aarch64`, not `arm64`, on Linux aarch64.