### PR TITLE
Add missing test toolchains

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -796,10 +796,74 @@ jobs:
         \ + \"\"\",\n    target_settings = \"\"\" + repr(rctx.attr.target_settings)\
         \ + \"\"\",\n    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl\"\
         ,\n    toolchain_type = \"@bazel_tools//tools/cpp:toolchain_type\",\n)\n\"\
-        \"\",\n    )\n\ntoolchain_repo = repository_rule(\n    implementation = _toolchain_repo,\n\
-        \    attrs = {\n        \"extra_exec_compatible_with\": attr.string_list(),\n\
-        \        \"extra_target_compatible_with\": attr.string_list(),\n        \"\
-        target_settings\": attr.string_list(),\n    },\n)\n\ndef load_musl_toolchains(extra_exec_compatible_with=[],\
+        \"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n\
+        \    target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl//:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n\
+        \    target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl//:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n\
+        \    target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl//:musl-1_2_3-platform-x86_64-apple-darwin-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:x86_64\",\n   \
+        \     \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n\
+        \        \"@platforms//cpu:x86_64\",\n        \"@platforms//os:linux\",\n\
+        \    ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n\
+        \    target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl//:musl-1_2_3-platform-aarch64-apple-darwin-target-x86_64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n \
+        \   target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl//:musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n \
+        \   target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl//:musl-1_2_3-platform-aarch64-unknown-linux-gnu-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n \
+        \   target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl//:musl-1_2_3-platform-x86_64-apple-darwin-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\" + \"\"\"toolchain(\n    name = \"musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    exec_compatible_with = [\n        \"@platforms//cpu:arm64\",\n    \
+        \    \"@platforms//os:linux\",\n    ],\n    target_compatible_with = [\n \
+        \       \"@platforms//cpu:arm64\",\n        \"@platforms//os:linux\",\n  \
+        \  ] + \"\"\" + repr(rctx.attr.extra_target_compatible_with) + \"\"\",\n \
+        \   target_settings = \"\"\" + repr(rctx.attr.target_settings) + \"\"\",\n\
+        \    toolchain = \"@musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl//:musl-1_2_3-platform-aarch64-apple-darwin-target-aarch64-linux-musl_test_toolchain\"\
+        ,\n    toolchain_type = \"@bazel_tools//tools/cpp:test_runner_toolchain_type\"\
+        ,\n)\n\"\"\",\n    )\n\ntoolchain_repo = repository_rule(\n    implementation\
+        \ = _toolchain_repo,\n    attrs = {\n        \"extra_exec_compatible_with\"\
+        : attr.string_list(),\n        \"extra_target_compatible_with\": attr.string_list(),\n\
+        \        \"target_settings\": attr.string_list(),\n    },\n)\n\ndef load_musl_toolchains(extra_exec_compatible_with=[],\
         \ extra_target_compatible_with=[], target_settings=[]):\n    http_archive(\n\
         \        name = \"musl-1_2_3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl\"\
         ,\n        sha256 = \"$(sha256sum musl-1.2.3-platform-x86_64-unknown-linux-gnu-target-x86_64-linux-musl.tar.gz\

--- a/generate-actions.py
+++ b/generate-actions.py
@@ -389,6 +389,18 @@ def generate_release_archive(toolchain_infos, output_path, version):
                 target_settings_expr="rctx.attr.target_settings",
             )
             for artifact in toolchain_infos
+        ] + [
+            generate_test_toolchain(
+                artifact.repo_name,
+                artifact.target_arch,
+                wrap_in_triple_quotes=True,
+                # Explicitly omit extra_exec_compatible_with as the test
+                # binaries have no exec platform requirements beyond matching
+                # OS/CPU.
+                extra_target_compatible_expr="rctx.attr.extra_target_compatible_with",
+                target_settings_expr="rctx.attr.target_settings",
+            )
+            for artifact in toolchain_infos
         ]
     )
 


### PR DESCRIPTION
The test toolchains weren't generated into release archives, only into the builder test workspaces.